### PR TITLE
Bug/Set font instead of font name and font size separately

### DIFF
--- a/Pod/Classes/MBCircularProgressBarLayer.h
+++ b/Pod/Classes/MBCircularProgressBarLayer.h
@@ -56,11 +56,6 @@ typedef NS_ENUM(NSInteger, MBCircularProgressBarAppearanceType) {
 @property (nonatomic,assign) NSTimeInterval  animationDuration;
 
 /**
- * The font size of the value text	[0,∞)
- */
-@property (nonatomic,assign) CGFloat  valueFontSize;
-
-/**
  * The name of the font of the unit string
  */
 @property (nonatomic,assign) CGFloat  unitFontSize;
@@ -132,7 +127,7 @@ typedef NS_ENUM(NSInteger, MBCircularProgressBarAppearanceType) {
 /**
  * The name of the font of the unit string
  */
-@property (nonatomic,copy)    NSString  *valueFontName;
+@property (nonatomic,copy)    UIFont  *valueFont;
 
 /**
  * Should show unit screen

--- a/Pod/Classes/MBCircularProgressBarLayer.m
+++ b/Pod/Classes/MBCircularProgressBarLayer.m
@@ -15,7 +15,6 @@
 @dynamic value;
 @dynamic maxValue;
 @dynamic borderPadding;
-@dynamic valueFontSize;
 @dynamic unitString;
 @dynamic unitFontSize;
 @dynamic progressLineWidth;
@@ -33,7 +32,7 @@
 @dynamic decimalPlaces;
 @dynamic valueDecimalFontSize;
 @dynamic unitFontName;
-@dynamic valueFontName;
+@dynamic valueFont;
 @dynamic showUnitString;
 @dynamic showValueString;
 @dynamic textOffset;
@@ -146,10 +145,10 @@
 - (void)drawText:(CGRect)rect context:(CGContextRef)c{
   NSMutableParagraphStyle* textStyle = NSMutableParagraphStyle.defaultParagraphStyle.mutableCopy;
   textStyle.alignment = NSTextAlignmentLeft;
-  
-  CGFloat valueFontSize = self.valueFontSize == -1 ? CGRectGetHeight(rect)/5 : self.valueFontSize;
-  
-  NSDictionary* valueFontAttributes = @{NSFontAttributeName: [UIFont fontWithName: self.valueFontName size:valueFontSize], NSForegroundColorAttributeName: self.fontColor, NSParagraphStyleAttributeName: textStyle};
+
+  NSDictionary* valueFontAttributes = @{NSFontAttributeName: self.valueFont,
+                                        NSForegroundColorAttributeName: self.fontColor,
+                                        NSParagraphStyleAttributeName: textStyle};
   
   NSMutableAttributedString *text = [NSMutableAttributedString new];
   
@@ -168,7 +167,9 @@
   // set the decimal font size
   NSUInteger decimalLocation = [text.string rangeOfString:@"."].location;
   if (decimalLocation != NSNotFound){
-    NSDictionary* valueDecimalFontAttributes = @{NSFontAttributeName: [UIFont fontWithName: self.valueFontName size:self.valueDecimalFontSize == -1 ? valueFontSize : self.valueDecimalFontSize], NSForegroundColorAttributeName: self.fontColor, NSParagraphStyleAttributeName: textStyle};
+    NSDictionary* valueDecimalFontAttributes = @{NSFontAttributeName: valueFont,
+                                                 NSForegroundColorAttributeName: self.fontColor,
+                                                 NSParagraphStyleAttributeName: textStyle};
     NSRange decimalRange = NSMakeRange(decimalLocation, text.length - decimalLocation);
     [text setAttributes:valueDecimalFontAttributes range:decimalRange];
   }

--- a/Pod/Classes/MBCircularProgressBarLayer.m
+++ b/Pod/Classes/MBCircularProgressBarLayer.m
@@ -167,7 +167,7 @@
   // set the decimal font size
   NSUInteger decimalLocation = [text.string rangeOfString:@"."].location;
   if (decimalLocation != NSNotFound){
-    NSDictionary* valueDecimalFontAttributes = @{NSFontAttributeName: valueFont,
+    NSDictionary* valueDecimalFontAttributes = @{NSFontAttributeName: self.valueFont,
                                                  NSForegroundColorAttributeName: self.fontColor,
                                                  NSParagraphStyleAttributeName: textStyle};
     NSRange decimalRange = NSMakeRange(decimalLocation, text.length - decimalLocation);

--- a/Pod/Classes/MBCircularProgressBarView.h
+++ b/Pod/Classes/MBCircularProgressBarView.h
@@ -41,14 +41,9 @@ IB_DESIGNABLE
 @property (nonatomic,assign) IBInspectable NSInteger decimalPlaces;
 
 /** 
- * The name of the font of the value string
+ * The font of the value string
  */
-@property (nonatomic,copy)   IBInspectable NSString  *valueFontName;
-
-/**
- * The font size of the value text	[0,∞) 
- */
-@property (nonatomic,assign) IBInspectable CGFloat   valueFontSize;
+@property (nonatomic,copy) UIFont  *valueFont;
 
 /** 
  * The value to be displayed in the center 

--- a/Pod/Classes/MBCircularProgressBarView.m
+++ b/Pod/Classes/MBCircularProgressBarView.m
@@ -65,6 +65,7 @@
     [self setTextOffset:CGPointMake(0, 0)];
     [self setUnitFontName:@"HelveticaNeue-Thin"];
     [self setCountdown:NO];
+    [self setValueFont:[UIFont boldSystemFontOfSize:60]];
 }
 
 #pragma mark - Getters and Setters for layer properties

--- a/Pod/Classes/MBCircularProgressBarView.m
+++ b/Pod/Classes/MBCircularProgressBarView.m
@@ -58,12 +58,10 @@
     [self setProgressLineWidth:14.f];
     [self setProgressAngle:80.f];
     [self setUnitFontSize:-1];
-    [self setValueFontSize:-1];
     [self setValueDecimalFontSize:-1];
     [self setDecimalPlaces:0];
     [self setShowUnitString:YES];
     [self setShowValueString:YES];
-    [self setValueFontName:@"HelveticaNeue-Thin"];
     [self setTextOffset:CGPointMake(0, 0)];
     [self setUnitFontName:@"HelveticaNeue-Thin"];
     [self setCountdown:NO];
@@ -144,14 +142,6 @@
 
 -(CGFloat)unitFontSize{
     return self.progressLayer.unitFontSize;
-}
-
--(void)setValueFontSize:(CGFloat)valueFontSize{
-    self.progressLayer.valueFontSize = valueFontSize;
-}
-
--(CGFloat)valueFontSize{
-    return self.progressLayer.valueFontSize;
 }
 
 -(void)setUnitString:(NSString *)unitString{
@@ -273,12 +263,12 @@
   return self.progressLayer.unitFontName;
 }
 
--(void)setValueFontName:(NSString *)valueFontName{
-  self.progressLayer.valueFontName = valueFontName;
+-(void)setValueFont:(UIFont *)valueFont{
+  self.progressLayer.valueFont = valueFont;
 }
 
--(NSString *)valueFontName{
-  return self.progressLayer.valueFontName;
+-(NSString *)valueFont{
+  return self.progressLayer.valueFont;
 }
 
 -(void)setShowUnitString:(BOOL)showUnitString{


### PR DESCRIPTION
## Description

#### Why?
On iOS 13 passing system font name in `UIFont` doesn't work as it should. It results in wrong font used. The idea is to provide property to pass whole font object instead of font name and font size separately.

#### Overview
- Removed `valueFontSize` and `valueFontName` properties to set
- Added new param `valueFont` instead.
- Set default font

